### PR TITLE
Fix cypress tests

### DIFF
--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -1,13 +1,13 @@
 describe('What user sees on home page', () => {
 	beforeEach(() => {
+    cy.intercept('GET', 'https://cryptic-thicket-07538-399494341bbd.herokuapp.com/api/v1/watches', {
+			statusCode: 200,
+			fixture: 'example.json'
+    })
 		cy.visit('http://localhost:3000');
 	});
   
 	it('Should show the name of the app, a form, a collection of watches, should hold the value in the form input when data is entered, navigate to /results after button click, and display search results on /results page', () => {
-		cy.intercept('GET', 'https://cryptic-thicket-07538-399494341bbd.herokuapp.com/api/v1/watches', {
-			statusCode: 200,
-			fixture: 'example.json'
-		})
 		cy.get('header').within(() => {
       cy.get('img').should('exist');
     });


### PR DESCRIPTION
this PR will move the intercept in the cypress tests into the beforeEach and before the cy.visit, so that all of the fetch requests will be intercepted, as opposed to some of them, this is not a breaking change, there are no bugs, (just some proptype issues), there are thorough tests and I have reviewed my code